### PR TITLE
Add shell script for easy start/stop

### DIFF
--- a/harbour.sh
+++ b/harbour.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+# Make sure Docker is running first
+
+# Start the backend 
+make -C backend d.up && sleep 1
+make -C backend db.update
+
+make -C backend build
+backend/out/bin/harbour-api&
+echo $! > server.pid
+
+# Start the frontend
+cd harbour_frontend && flutter run
+
+# Stop
+cd ..
+kill $(cat server.pid)
+make -C backend d.down
+rm server.pid


### PR DESCRIPTION
Add a new shell script to easily start/stop the full stack. You can run the server on Linux from the project root with "./harbour.sh". The script automatically handles starting/stopping the containers, the backend server, and Flutter. You will still need to launch Docker first though.