### PR TITLE
Reorganized some endpoints

### DIFF
--- a/backend/pkg/common/router/router.go
+++ b/backend/pkg/common/router/router.go
@@ -55,20 +55,24 @@ func LoadRouter(handler *Handler) *echo.Echo {
 	e.POST("/signin", handler.SignIn)
 	e.GET("/users/:id", handler.GetUser)
 
-	restricted := e.Group("/restricted")
-
 	config := echojwt.Config{
 		NewClaimsFunc: func(c echo.Context) jwt.Claims {
 			return new(util.UserTokenClaims)
 		},
 		SigningKey: util.SampleSecretKey,
 	}
-	restricted.Use(echojwt.WithConfig(config))
-	restricted.GET("/user", handler.GetUserByToken)
-	restricted.POST("/vessels", handler.CreateVessel)
-	restricted.GET("/getVessel", handler.GetVessel)
-	restricted.POST("/joinVessel", handler.JoinVessel)
-	restricted.GET("/getUsers", handler.GetUsers)
-	restricted.GET("/searchVessels", handler.SearchVessels)
+
+  user := e.Group("/user")
+	user.Use(echojwt.WithConfig(config))
+  user.GET("/", handler.GetUserByToken)
+
+  vessel := e.Group("/vessel")
+  vessel.Use(echojwt.WithConfig(config))
+  vessel.POST("/new", handler.CreateVessel)
+	vessel.GET("/", handler.GetVessel)
+	vessel.POST("/join", handler.JoinVessel)
+	vessel.GET("/members", handler.GetUsers)
+	vessel.GET("/search", handler.SearchVessels)
+
 	return e
 }

--- a/backend/pkg/common/router/user_test.go
+++ b/backend/pkg/common/router/user_test.go
@@ -97,7 +97,7 @@ func TestGetUserByToken(t *testing.T) {
 	ar := DoSignup(u, t)
 
 	// Call get user, passing up the access token as the AUTH header
-	req, rec := makeRequest(http.MethodGet, "/restricted/user", nil, ar.AccessToken)
+	req, rec := makeRequest(http.MethodGet, "/user/", nil, ar.AccessToken)
 	testEcho.ServeHTTP(rec, req)
 
 	assert.Equal(t, http.StatusOK, rec.Code)

--- a/backend/pkg/common/router/vessel_test.go
+++ b/backend/pkg/common/router/vessel_test.go
@@ -19,7 +19,7 @@ func TestCreateVessel(t *testing.T) {
 	ar := DoSignup(sr, t)
 	userId := ParseUserIdFromToken(ar.AccessToken, t)
 	vr := newVesselReq{Name: "Example", Administrator: userId}
-	req, rec := makeRequest(http.MethodPost, "/restricted/vessels", vr, ar.AccessToken)
+	req, rec := makeRequest(http.MethodPost, "/vessel/new", vr, ar.AccessToken)
 	testEcho.ServeHTTP(rec, req)
 	//fmt.Println(rec)
 	assert.Equal(t, http.StatusOK, rec.Code)
@@ -46,13 +46,13 @@ func TestVesselFeaturesUgly(t *testing.T) {
 	vr3 := joinVesselReq{User_Id: userId, Vessel: vessel.Id}
 	//fmt.Println(vr)
 	//fmt.Println(vr3)
-	req, rec := makeRequest(http.MethodPost, "/restricted/joinVessel", vr3, ar2.AccessToken)
+	req, rec := makeRequest(http.MethodPost, "/vessel/join", vr3, ar2.AccessToken)
 	testEcho.ServeHTTP(rec, req)
 	//fmt.Println(rec)
 	assert.Equal(t, http.StatusOK, rec.Code)
 
 	vr2 := getVesselReq{Id: vessel.Id}
-	req, rec = makeRequest(http.MethodGet, "/restricted/getVessel", vr2, ar2.AccessToken)
+	req, rec = makeRequest(http.MethodGet, "/vessel/", vr2, ar2.AccessToken)
 	testEcho.ServeHTTP(rec, req)
 	//fmt.Println(rec)
 	assert.Equal(t, http.StatusOK, rec.Code)
@@ -64,7 +64,7 @@ func TestVesselFeaturesUgly(t *testing.T) {
 	assert.Equal(t, vessel.Name, vesselResp.Name)
 
 	vr4 := usersInVesselReq{Vessel:vessel.Id}
-	req, rec = makeRequest(http.MethodGet, "/restricted/getUsers", vr4, ar2.AccessToken)
+	req, rec = makeRequest(http.MethodGet, "/vessel/members", vr4, ar2.AccessToken)
 	testEcho.ServeHTTP(rec, req)
 	assert.Equal(t, http.StatusOK, rec.Code)
 
@@ -75,7 +75,7 @@ func TestSearch(t *testing.T) {
 	userId := ParseUserIdFromToken(firstUser.AccessToken, t)
 
 	vr := newVesselReq{Name: "Blackbeard's Flagship", Administrator: userId}
-	req, rec := makeRequest(http.MethodPost, "/restricted/vessels", vr, firstUser.AccessToken)
+	req, rec := makeRequest(http.MethodPost, "/vessel/new", vr, firstUser.AccessToken)
 	testEcho.ServeHTTP(rec, req)
 	//fmt.Println(rec)
 	assert.Equal(t, http.StatusOK, rec.Code)
@@ -90,7 +90,7 @@ func TestSearch(t *testing.T) {
 	assert.Equal(t, vr.Name, firstVessel.Name)
 
 	vr = newVesselReq{Name: "Bluebeard's Best Ship Ever", Administrator: userId}
-	req, rec = makeRequest(http.MethodPost, "/restricted/vessels", vr, firstUser.AccessToken)
+	req, rec = makeRequest(http.MethodPost, "/vessel/new", vr, firstUser.AccessToken)
 	testEcho.ServeHTTP(rec, req)
 	//fmt.Println(rec)
 	assert.Equal(t, http.StatusOK, rec.Code)
@@ -103,7 +103,7 @@ func TestSearch(t *testing.T) {
 	assert.Equal(t, vr.Name, secondVessel.Name)
 
 	vr2 := searchVesselReq{Slug: "beard"}
-	req, rec = makeRequest(http.MethodGet, "/restricted/searchVessels", vr2, firstUser.AccessToken)
+	req, rec = makeRequest(http.MethodGet, "/vessel/search", vr2, firstUser.AccessToken)
 	testEcho.ServeHTTP(rec, req)
 	fmt.Println(rec)
 	assert.Equal(t, http.StatusOK, rec.Code)

--- a/harbour_frontend/lib/api/user_service.dart
+++ b/harbour_frontend/lib/api/user_service.dart
@@ -36,7 +36,7 @@ class UserService {
 
   Future<User> getUser(Token jwt) async {
     try {
-      final res = await dio.get('$server/restricted/user',
+      final res = await dio.get('$server/user/',
           options:
               Options(headers: {'Authorization': jwt.toString()}));
 

--- a/harbour_frontend/lib/pages/user-vessel-list.dart
+++ b/harbour_frontend/lib/pages/user-vessel-list.dart
@@ -2,6 +2,8 @@ import 'dart:async';
 
 import 'package:flutter/material.dart';
 
+import '../models/user_model.dart';
+
 //THIS FILE IS CURRENTLY STANDALONE AND WILL HAVE TO BE INTEGRATED
 //TO INCLUDE THE CORRECT DATA STRUCTURES AND JSON REQUESTS FROM
 //VESSELS.dart FILE


### PR DESCRIPTION
I reorganized some of the endpoints. The restricted group no longer exists and is now split between the "user" group and the "vessel" group. Here are some of the important changes:

- Creating a vessel is now "/vessel/new" instead of "/restricted/vessels"
- Getting a vessel is now "/vessel/" instead of "/restricted/getVessel"
- Getting a user is now "/user/" instead of "restricted/user"

All of the test files and the frontend have been updated to account for these changes.